### PR TITLE
Use standard SLOT-BOUNDP and SLOT-VALUE instead

### DIFF
--- a/src/jzon.lisp
+++ b/src/jzon.lisp
@@ -1128,11 +1128,12 @@ see `close-parser'"
              `(let ((class (class-of ,element)))
                 (c2mop:ensure-finalized class)
                 (mapcar (lambda (s)
-                          (list (c2mop:slot-definition-name s)
-                                (c2mop:slot-value-using-class class ,element s)
-                                (c2mop:slot-definition-type s)))
-                        (remove-if-not (lambda (s) (c2mop:slot-boundp-using-class class ,element s))
-                                       (c2mop:class-slots class))))))
+                          (let ((slot-name (c2mop:slot-definition-name s)))
+                            (list slot-name
+                                  (slot-value ,element slot-name)
+                                  (c2mop:slot-definition-type s))))
+                          (remove-if-not (lambda (s) (slot-boundp ,element (c2mop:slot-definition-name s)))
+                                         (c2mop:class-slots class))))))
   (defgeneric coerced-fields (element)
     (:documentation "Return a list of key definitions for `element'.
  A key definition is a three-element list of the form


### PR DESCRIPTION
This fixed #49 .

According to the maintainer of CLOSER-MOP, `c2mop:slot-boundp-using-class` should not be used directly. In extension, I've already had to replace `c2mop:slot-value-using-class` with the standard's `slot-value`. 

Now `stringify` works on both LispWorks 8 and SBCL (for me).